### PR TITLE
README: Add hint about no XML reports for base

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ A simple Odoo module that overrides `openerp.modules.module.run_unit_tests` so i
 This generates XML files that can be read by other software such as SonarQube.
 
 ## Important info ##
- - The module needs to be installed on the database before tests are run in order for the override to work
+ - The module needs to be installed on the database before tests are run in
+   order for the override to work. Even then, XML files will only be generated
+   for the tests from modules that are *loaded* after this module
+    (`xml_test_output`). This means that **no XML files will be generated for
+    the results of the tests in `base`**, because `base` is always loaded first.
  - The output directory can be set via the test_report_directory option in your server.cfg file, it defaults to 'tests'
 
 ## Todos


### PR DESCRIPTION
xml_test_output monkey patches openerp.modules.module.run_unit_tests to
generate XML reports for unit tests. It won't do so for the unit tests
in base, because base is loaded before xml_test_output and at that time
the monkey patch isn't in place yet. Note this in the README, because
otherwise people might not realize that they won't get the reports for
many of their tests.