### PR TITLE
README: Enable XML output for base with --load

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@ A simple Odoo module that overrides `openerp.modules.module.run_unit_tests` so i
 This generates XML files that can be read by other software such as SonarQube.
 
 ## Important info ##
- - The module needs to be installed on the database before tests are run in
-   order for the override to work. Even then, XML files will only be generated
-   for the tests from modules that are *loaded* after this module
-    (`xml_test_output`). This means that **no XML files will be generated for
-    the results of the tests in `base`**, because `base` is always loaded first.
+ - The module needs to be installed on the database before tests are executed.
+   So you need to run Odoo twice:
+
+        $ ./odoo -d <DB name> -i xml_test_output --stop-after-init
+        $ ./odoo -d <DB name> --load=xml_test_output,web,web_kanban \
+              -i <modules to install and test> \
+              --test-enable --stop-after-init
+
+ - The `--load=…` in the previous snippet causes Odoo to `import
+   ….xml_test_output` before the modules in `base`. If you don't pass
+   `--load=…`, Odoo won't generate XML files for the tests from `base`.
+   `web,web_kanban` is the default value for `--load`.
  - The output directory can be set via the test_report_directory option in your server.cfg file, it defaults to 'tests'
 
 ## Todos


### PR DESCRIPTION
Previously I had added a note that xml_test_output won't output XML
reports for the tests in base. A coworker made me aware that this is
wrong. With the --load argument you can tell Odoo to import
xml_test_output first and thus enable XML reports for the tests in base.
Update the README accordingly.